### PR TITLE
Run LDConfig

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,6 +8,7 @@ use Config;
 my $perlbin = $Config{perlpath};
 my $perlversion = $Config{version};
 my $siteprefix = $Config{siteprefix};
+my $dataprefix = $Config{siteprefix} . '/etc/';
 
 my $core_lib =  $Config{archlib}.'/CORE/';
 my $use_threads = $Config{usethreads} ? '' : '--without-threads';
@@ -44,6 +45,8 @@ my $builder = Alien::Base::ModuleBuild->new(
         exact_filename => 'ImageMagick.tar.gz'
     },
 
+    alien_install_type => 'share',
+
     ## For development, to save the download time,
     ## download the package once and put it in an 'inc' directory.
     # alien_repository => {
@@ -53,7 +56,7 @@ my $builder = Alien::Base::ModuleBuild->new(
     #                    },
     alien_build_commands => [
                              ## This siteprefix will install the execs in perl's /bin and the libs in perl's lib/
-                             'LDFLAGS='.$LDFLAGS.' %c --prefix=%s --exec-prefix='.$siteprefix.' --with-perl='.$perlbin.' '.$enable_shared.' '.$use_threads ,
+                             'LDFLAGS='.$LDFLAGS.' %c --prefix=%s --sysconfdir='.$dataprefix.' --exec-prefix='.$siteprefix.' --with-perl='.$perlbin.' '.$enable_shared.' '.$use_threads . ' --with-modules',
 
                              # Patch the PerlMagick makefiles to reflect lib installation places.
                              # This is because ImageMagic's PerlMagick package comes with Makefile.PL files

--- a/Build.PL
+++ b/Build.PL
@@ -16,6 +16,7 @@ my $enable_shared = ( ( $Config{useshrplib} || '' ) eq 'false' ) ? '' : '--enabl
 my $LDFLAGS= '-L'.$core_lib;
 
 my ($ldconfig) = grep { -x } map { "$_/ldconfig" } split(/:/, $ENV{PATH});
+$ldconfig = "$ldconfig || true" if $ldconfig;
 
 my $builder = Alien::Base::ModuleBuild->new(
     module_name         => 'Alien::ImageMagick',

--- a/Build.PL
+++ b/Build.PL
@@ -14,6 +14,8 @@ my $use_threads = $Config{usethreads} ? '' : '--without-threads';
 my $enable_shared = ( ( $Config{useshrplib} || '' ) eq 'false' ) ? '' : '--enable-shared';
 my $LDFLAGS= '-L'.$core_lib;
 
+my ($ldconfig) = grep { -x } map { "$_/ldconfig" } split(/:/, $ENV{PATH});
+
 my $builder = Alien::Base::ModuleBuild->new(
     module_name         => 'Alien::ImageMagick',
     license             => 'perl',
@@ -45,13 +47,13 @@ my $builder = Alien::Base::ModuleBuild->new(
     ## For development, to save the download time,
     ## download the package once and put it in an 'inc' directory.
     # alien_repository => {
-    #                      protocol => 'local',
-    #                      location => 'inc',
-    #                      exact_filename => 'ImageMagick.tar.gz',
-    #                     },
+    #                     protocol => 'local',
+    #                     location => 'inc',
+    #                     exact_filename => 'ImageMagick.tar.gz',
+    #                    },
     alien_build_commands => [
                              ## This siteprefix will install the execs in perl's /bin and the libs in perl's lib/
-                             'LDFLAGS='.$LDFLAGS.' %pconfigure --prefix=%s --exec-prefix='.$siteprefix.' --with-perl='.$perlbin.' '.$enable_shared.' '.$use_threads ,
+                             'LDFLAGS='.$LDFLAGS.' %c --prefix=%s --exec-prefix='.$siteprefix.' --with-perl='.$perlbin.' '.$enable_shared.' '.$use_threads ,
 
                              # Patch the PerlMagick makefiles to reflect lib installation places.
                              # This is because ImageMagic's PerlMagick package comes with Makefile.PL files
@@ -73,7 +75,9 @@ my $builder = Alien::Base::ModuleBuild->new(
     ],
     alien_install_commands => [
         'LDFLAGS='.$LDFLAGS.' make install', # This will build the included PerlMagick package.
+        $ldconfig // "",
         $perlbin.' -e "use Image::Magick; print Image::Magick->QuantumDepth"', # This checks Image magick is there fine.
+
     ],
     meta_merge => {
         resources  => {
@@ -83,3 +87,4 @@ my $builder = Alien::Base::ModuleBuild->new(
 );
 
 $builder->create_build_script();
+

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Alien-ImageMagick
 
 0.08
         Run ldconfig after installation, to be sure the test works.
+        Instruct ImageMagick to build all modules, or library will get unresolved symbols
+        Workout the way data folder for delegations is computed    
 
 0.07    2016-03-02
         Make sure that Alien::Base::ModuleBuild is correctly specified as a configure_requires. Thanks @plicease

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Alien-ImageMagick
 
+0.08
+        Run ldconfig after installation, to be sure the test works.
+
 0.07    2016-03-02
         Make sure that Alien::Base::ModuleBuild is correctly specified as a configure_requires. Thanks @plicease
         PR #2

--- a/lib/Alien/ImageMagick.pm
+++ b/lib/Alien/ImageMagick.pm
@@ -12,11 +12,11 @@ Alien::ImageMagick - cpanm compatible Image::Magick packaging.
 
 =head1 VERSION
 
-Version 0.06
+Version 0.08
 
 =cut
 
-our $VERSION = '0.07';
+our $VERSION = '0.08';
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Hi
Even when installing in `/usr/local/`, if a `ldconfig` is not run, the test (`perl -MImage::Magick`) will fail.
The patch is as simple as:
 - check if we have `ldconfig` in the path
 - if we have, try to run it.
Will be happy to release a new version (and prepare PR for it).
As I am using this module, having It on CPAN with the fix would be great.
Thank you