### PR TITLE
don't run empty string if ldconfig is absent from $PATH

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -79,7 +79,7 @@ my $builder = Alien::Base::ModuleBuild->new(
     ],
     alien_install_commands => [
         'LDFLAGS='.$LDFLAGS.' make install', # This will build the included PerlMagick package.
-        $ldconfig // "",
+        $ldconfig // (),
         $perlbin.' -e "use Image::Magick; print Image::Magick->QuantumDepth"', # This checks Image magick is there fine.
 
     ],


### PR DESCRIPTION
Fixes #11

Worked for me, anyway.